### PR TITLE
README: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Example
 
     this is some code
 
-A regular paragraph"
+A regular paragraph")
 
 ;; Parses the CommonMark.
 (define doc-sxml (commonmark->sxml doc))


### PR DESCRIPTION
Just a closing parenthesis for `doc` variable.
